### PR TITLE
scanner: remove newlines and extra spaces from enum entry summaries

### DIFF
--- a/scanner/source/wayland/scanner/common.d
+++ b/scanner/source/wayland/scanner/common.d
@@ -16,6 +16,7 @@ import std.exception;
 import std.format;
 import std.range;
 import std.stdio;
+import std.string;
 import std.typecons;
 import std.uni;
 
@@ -233,6 +234,8 @@ class EnumEntry
     {
         if (summary.length)
         {
+            summary = replace(summary, "\n", " ");
+            summary = tr(summary, " ", " ", "s");
             sf.writeln("/// %s", summary);
         }
         sf.writeln(


### PR DESCRIPTION
With the current scanner, this enum in the `xdg_toplevel` interface in [`wayland-protocols/stable/xdg-shell/xdg-shell.xml`](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/stable/xdg-shell/xdg-shell.xml#L608-611):
```xml
    <enum name="error">
      <entry name="invalid_resize_edge" value="0" summary="provided value is
        not a valid variant of the resize_edge enum"/>
    </enum>
```
is turned into this:
```d
    enum Error : uint
    {
        /// provided value is
                not a valid variant of the resize_edge enum
        invalidResizeEdge = 0,
    }
```
which obviously fails to compile:
```
xdg_shell.d(924): Error: `not` is not a valid attribute for enum members
xdg_shell.d(924): Error: `a` is not a valid attribute for enum members
xdg_shell.d(924): Error: `valid` is not a valid attribute for enum members
xdg_shell.d(924): Error: `variant` is not a valid attribute for enum members
xdg_shell.d(924): Error: `of` is not a valid attribute for enum members
xdg_shell.d(924): Error: `the` is not a valid attribute for enum members
xdg_shell.d(924): Error: `resize_edge` is not a valid attribute for enum members
xdg_shell.d(924): Error: `enum` is not a valid attribute for enum members
```

Strip newlines and extra spaces from enum entry summaries to get them generated properly like this:
```d
    enum Error : uint
    {
        /// provided value is not a valid variant of the resize_edge enum
        invalidResizeEdge = 0,
    }
```