### PR TITLE
Fix the handling of allow-null arguments

### DIFF
--- a/scanner/source/wayland/scanner/client.d
+++ b/scanner/source/wayland/scanner/client.d
@@ -92,7 +92,14 @@ class ClientArg : Arg
                 return Arg.cCastExpr;
             case ArgType.NewId:
             case ArgType.Object:
-                return format("%s.proxy", paramName);
+                if (nullable)
+                {
+                    return format("%1$s is null ? null : %1$s.proxy", paramName);
+                }
+                else
+                {
+                    return format("%s.proxy", paramName);
+                }
         }
     }
 

--- a/scanner/source/wayland/scanner/common.d
+++ b/scanner/source/wayland/scanner/common.d
@@ -901,6 +901,7 @@ string validDName(in string name) pure
         case "alias": return "alias_";
         case "class": return "class_";
         case "default": return "default_";
+        case "immutable": return "immutable_";
         case "interface": return "iface";
         case "version": return "version_";
         default:


### PR DESCRIPTION
When arguments can be null, to pass null we had to wrap it in D type. Now we can just pass null.