### PR TITLE
Add support for wl_display_set_default_max_buffer_size

### DIFF
--- a/server/source/wayland/native/server.d
+++ b/server/source/wayland/native/server.d
@@ -375,6 +375,8 @@ version(WlDynamic)
         alias da_wl_display_add_protocol_logger = wl_protocol_logger* function (wl_display* display, wl_protocol_logger_func_t, void* user_data);
 
         alias da_wl_protocol_logger_destroy = void function (wl_protocol_logger* logger);
+
+        alias da_wl_display_set_default_max_buffer_size = void function (wl_display* display, size_t max_buffer_size);
     }
 
     __gshared
@@ -466,6 +468,7 @@ version(WlDynamic)
         da_wl_log_set_handler_server wl_log_set_handler_server;
         da_wl_display_add_protocol_logger wl_display_add_protocol_logger;
         da_wl_protocol_logger_destroy wl_protocol_logger_destroy;
+        da_wl_display_set_default_max_buffer_size wl_display_set_default_max_buffer_size;
     }
 }
 
@@ -647,6 +650,8 @@ version(WlStatic)
         wl_protocol_logger* wl_display_add_protocol_logger(wl_display* display, wl_protocol_logger_func_t, void* user_data);
 
         void wl_protocol_logger_destroy(wl_protocol_logger* logger);
+
+        void wl_display_set_default_max_buffer_size(wl_display* display, size_t max_buffer_size);
     }
 }
 

--- a/server/source/wayland/server/core.d
+++ b/server/source/wayland/server/core.d
@@ -147,6 +147,11 @@ class WlDisplayBase : Native!wl_display
         return _clients;
     }
 
+    void setDefaultMaxBufferSize(size_t maxBufferSize)
+    {
+        wl_display_set_default_max_buffer_size(native, maxBufferSize);
+    }
+
     void initShm()
     {
         wl_display_init_shm(native);

--- a/server/source/wayland/server/package.d
+++ b/server/source/wayland/server/package.d
@@ -109,6 +109,7 @@ version(WlDynamic)
             bindFunc( cast( void** )&wl_log_set_handler_server, "wl_log_set_handler_server" );
             bindFunc( cast( void** )&wl_display_add_protocol_logger, "wl_display_add_protocol_logger" );
             bindFunc( cast( void** )&wl_protocol_logger_destroy, "wl_protocol_logger_destroy" );
+            bindFunc( cast( void** )&wl_display_set_default_max_buffer_size, "wl_display_set_default_max_buffer_size" );
 
             bindFunc( cast( void** )&wl_list_init, "wl_list_init" );
             bindFunc( cast( void** )&wl_list_insert, "wl_list_insert" );


### PR DESCRIPTION
Adds binds for `wl_display_set_default_max_buffer_size`.

Wayland clients like games tend to out-grow the servers default buffer size,
seems like the common solution in Wayland compositors is to use this function
to set a more reasonable buffer size which is also what I'm doing now.